### PR TITLE
intrinsicContentSize updates based on the number of pages

### DIFF
--- a/BFPageControl.m
+++ b/BFPageControl.m
@@ -268,6 +268,8 @@
     _numberOfPages = numberOfPages;
     
     [self updateCurrentPageDisplay];
+  
+    [self invalidateIntrinsicContentSize];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -289,9 +291,7 @@
 //! size to fit the current setting
 - (NSSize)intrinsicContentSize {
 
-    NSSize size = _matrix.frame.size;
-    return size;
-
+  return [self sizeForNumberOfPages:[self numberOfPages]];
 }
 
 - (NSSize)fittingSize {


### PR DESCRIPTION
intrinsicContentSize now returns the correct size based on the number of pages. invalidateIntrinsicContentSize now gets called when numberOfPages changes.
